### PR TITLE
Use Ana06's action instead of jitterbug's

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.1.0
         with:
           format: csv
 


### PR DESCRIPTION
Because Ana06 keeps her action up-to-date.
