### PR TITLE
Add CRAN status checks

### DIFF
--- a/.github/workflows/common.yml.inactive
+++ b/.github/workflows/common.yml.inactive
@@ -28,6 +28,8 @@ on:
   # you guessed it - when releases are made.
   release:
     types: [published]
+  schedule:
+    - cron: '21 13 * * 1,3,5'
 
 env:
   # R version to use for the workflows
@@ -120,3 +122,14 @@ jobs:
     if: github.event_name == 'pull_request'
     with:
       r-version: $R_VERSION
+  cran-status:
+    name: CRAN Status
+    uses: pharmaverse/admiralci/.github/workflows/cran-status.yml@main
+    if: github.event_name == 'schedule'
+    with:
+      # Whom should the issue be assigned to if errors are encountered
+      # in the CRAN status checks?
+      issue-assignees: ""
+      # Create an issue if one or more of the following
+      # statuses are reported on the check report.
+      status-types: "NOTE,WARNING,ERROR"

--- a/.github/workflows/cran-status.yml
+++ b/.github/workflows/cran-status.yml
@@ -62,7 +62,7 @@ jobs:
             status_types <- "${{ inputs.status-types }}"
             statuses <- unlist(strsplit(status_types, split = ","))
             cran_status <- function(x) {
-              cat(x, file="cran-status.md", append=TRUE)
+              cat(x, file="cran-status.md", append=TRUE, sep="\n")
             }
             if (any(checks$Status %in% statuses)) {
               cran_status(sprintf(
@@ -70,10 +70,10 @@ jobs:
                 pkg,
                 status_types
               ))
-              cran_status("\nSee table for summary of checks:\n")
+              cran_status("\nSee the table below for a summary of the checks run by CRAN:\n\n")
               cran_status(knitr::kable(checks))
               cran_status(sprintf(
-                "\nAll details and logs are available here: %s", url
+                "\n\nAll details and logs are available here: %s", url
               ))
               stop("❌ One or more CRAN checks resulted in an invalid status ❌")
             }

--- a/.github/workflows/cran-status.yml
+++ b/.github/workflows/cran-status.yml
@@ -1,0 +1,90 @@
+---
+name: CRAN Status
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      issue-assignees:
+        description: |
+          Whom should the issue be assigned to if errors are
+          encountered in the CRAN status checks?
+          This is a comma-separated string of GitHub usernames.
+          If undefined or empty, no assignments are made.
+        default: ''
+        required: false
+        type: string
+      status-types:
+        description: |
+          Create an issue if one or more of the following
+          statuses are reported on the check report.
+          This is a comma-separated string of statuses.
+          Allowed statuses are 'NOTE', 'WARNING', and 'ERROR'
+        default: 'ERROR'
+        required: false
+        type: string
+      path:
+        description: |
+          Path to the R package root, if the package is not at the
+          top level of the repository.
+        default: '.'
+        required: false
+        type: string
+
+concurrency:
+  group: cran-status-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cran-status:
+    name: Check Status
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Get Date
+        id: today
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Check Status
+        run: |
+          pkg <- paste(desc::desc_get(keys="Package"))
+          url <- sprintf("https://cran.r-project.org/web/checks/check_results_%s.html", pkg)
+          if (!httr::http_error(url)) {
+            library(rvest)
+            checks <- url %>%
+              read_html() %>%
+              html_element("table") %>%
+              html_table()
+            status_types <- "${{ inputs.status-types }}"
+            statuses <- unlist(strsplit(status_types, split = ","))
+            cran_status <- function(x) {
+              cat(x, file="cran-status.md", append=TRUE)
+            }
+            if (any(checks$Status %in% statuses)) {
+              cran_status(sprintf(
+                "CRAN checks for %s resulted in one or more (%s)s:\n\n",
+                pkg,
+                status_types
+              ))
+              cran_status("\nSee table for summary of checks:\n")
+              cran_status(knitr::kable(checks))
+              cran_status(sprintf(
+                "\nAll details and logs are available here: %s", url
+              ))
+              stop("❌ One or more CRAN checks resulted in an invalid status ❌")
+            }
+          }
+        shell: Rscript {0}
+        working-directory: ${{ inputs.path }}
+
+      - name: Report Status
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: "URGENT! Failed CRAN Checks: ${{ steps.today.outputs.date }}"
+          content-filepath: ./${{ inputs.path }}/cran-status.md
+          assignees: ${{ inputs.issue-assignees }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,4 @@ insightsengineering/thevalidatoR@v1.2.1
 https://packagemanager.rstudio.com/cran/__linux__/focal/latest
 tj-actions/branch-names@v5.4
 .*@users.noreply.github.com
+https://cran.r-project.org/web/checks/check_results_%s.html

--- a/README.Rmd
+++ b/README.Rmd
@@ -116,6 +116,14 @@ Code style is enforced via the [`styler`][styler] R package. Custom style config
 
 Failed workflows are indicative of unstyled code.
 
+### [`cran-status.yml`](./.github/workflows/cran-status.yml)
+
+[![CRAN Status](https://github.com/pharmaverse/admiralci/actions/workflows/cran-status.yml/badge.svg)](https://github.com/pharmaverse/admiralci/actions/workflows/cran-status.yml)
+
+This workflow allows you to monitor the current status of checks on CRAN, if your package has been published on CRAN. Given that CRAN has its own systems on which it runs checks and it might not be possible to emulate all of their checks using GitHub Actions or CI/CD, it's just more efficient to let their systems run tests and be notified via a GitHub issue if an error is encountered.
+
+Usually CRAN sends out email notifications if errors are encountered during their checks but only individual package owners are notified and a stringent deadline of 2 weeks is given to remediate the errors on CRAN. To mititage the risk of the package being kicked off CRAN, this workflow provides transparency and visibility to all project collaborators by creating a GitHub issue so that the errors can be remediated before the deadline has passed.
+
 ## How to use these workflows?
 
 ### Reuse (recommended)

--- a/README.Rmd
+++ b/README.Rmd
@@ -122,7 +122,7 @@ Failed workflows are indicative of unstyled code.
 
 This workflow allows you to monitor the current status of checks on CRAN, if your package has been published on CRAN. Given that CRAN has its own systems on which it runs checks and it might not be possible to emulate all of their checks using GitHub Actions or CI/CD, it's just more efficient to let their systems run tests and be notified via a GitHub issue if an error is encountered.
 
-Usually CRAN sends out email notifications if errors are encountered during their checks but only individual package owners are notified and a stringent deadline of 2 weeks is given to remediate the errors on CRAN. To mititage the risk of the package being kicked off CRAN, this workflow provides transparency and visibility to all project collaborators by creating a GitHub issue so that the errors can be remediated before the deadline has passed.
+Usually CRAN sends out email notifications if errors are encountered during their checks but only individual package owners are notified and a stringent deadline of 2 weeks is given to remediate the errors on CRAN. To mitigate the risk of the package being kicked off CRAN, this workflow provides transparency and visibility to all project collaborators by creating a GitHub issue so that the errors can be remediated before the deadline has passed.
 
 ## How to use these workflows?
 


### PR DESCRIPTION
Adds a workflow that monitors the CRAN checks page for errors, notes, or warnings.
Closes https://github.com/pharmaverse/admiralci/issues/17