### PR TITLE
Eliminate R 3.6, and introduce R 4.1 Checks

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -34,8 +34,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: '3.6', repos: 'https://cran.microsoft.com/snapshot/2020-02-29/'}
           - {os: ubuntu-latest, r: '4.0', repos: 'https://cran.microsoft.com/snapshot/2021-03-31/'}
+          - {os: ubuntu-latest, r: '4.1', repos: 'https://cran.microsoft.com/snapshot/2021-03-31/'}
           - {os: ubuntu-20.04, r: 'release', repos: 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'}
 
     env:

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-latest, r: '4.0', repos: 'https://cran.microsoft.com/snapshot/2021-03-31/'}
-          - {os: ubuntu-latest, r: '4.1', repos: 'https://cran.microsoft.com/snapshot/2021-03-31/'}
+          - {os: ubuntu-latest, r: '4.1', repos: 'https://cran.microsoft.com/snapshot/2022-03-10/'}
           - {os: ubuntu-20.04, r: 'release', repos: 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'}
 
     env:


### PR DESCRIPTION
Remove R 3.6 and use R 4.1 instead. Tested on admiral here: https://github.com/pharmaverse/admiral/pull/1485