### PR TITLE
Ignore badge push for forks

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -226,3 +226,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: badges
           directory: badges
+        continue-on-error: true


### PR DESCRIPTION
So forkers are not confused by why the job fails during a PR.