### PR TITLE
33 Remove exclusion criteria for CI check

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -91,5 +91,4 @@ jobs:
       - name: Run Spellcheck
         uses: insightsengineering/r-spellcheck-action@v3
         with:
-          exclude: data/*,**/*.Rd,**/*.Rmd,**/*.md,**/*.qmd
           additional_options: ""


### PR DESCRIPTION
Before merge this small pr all the `WORDLIST` packages should be updated with.
Close #33 
```
spelling::update_wordlist()
```

- [x] admiraldev
- [x] admiral.test
- [x]  admiral
- [x]  admiralonco
- [x] admiralophtha
- [x] admiraltemplate
- [x]  ...
