### PR TITLE
#66 hot fix pkgdown shell escape issue

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -135,7 +135,7 @@ jobs:
           rlang::env_unlock(env = pkgdown_env)
           rlang::env_binding_unlock(env = pkgdown_env)
           # Modify tweak_page
-          pkgdown_env$call_hook <- function(hook_name, ...) {
+          call_hook <- function(hook_name, ...) {
             # Get hooks from base::getHook
             hooks <- getHook(paste0("UserHook::admiralci::", hook_name))
             if (!is.list(hooks)) {
@@ -148,8 +148,8 @@ jobs:
             }) %>%
               invisible()
           }
-          environment(pkgdown_env$call_hook) <- pkgdown_env
-
+          environment(call_hook) <- pkgdown_env
+          pkgdown_env$call_hook <- call_hook
           tweak_page <- body(pkgdown_env$tweak_page)
           body(pkgdown_env$tweak_page) <-
             as.call(

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -130,28 +130,22 @@ jobs:
           }
           fi
           Rscript - <<EOF
-
           pkgdown_env <- asNamespace("pkgdown")
           rlang::env_unlock(env = pkgdown_env)
           rlang::env_binding_unlock(env = pkgdown_env)
-          # Modify tweak_page
-          call_hook <- function(hook_name, ...) {
-            # Get hooks from base::getHook
+          pkgdown_env\$call_hook <- function(hook_name, ...) {
             hooks <- getHook(paste0("UserHook::admiralci::", hook_name))
             if (!is.list(hooks)) {
               hooks <- list(hooks)
             }
-
-            # Evaluate hooks
             purrr::map(hooks, function(fun) {
               fun(...)
             }) %>%
               invisible()
           }
-          environment(call_hook) <- pkgdown_env
-          pkgdown_env$call_hook <- call_hook
-          tweak_page <- body(pkgdown_env$tweak_page)
-          body(pkgdown_env$tweak_page) <-
+          environment(pkgdown_env\$call_hook) <- pkgdown_env
+          tweak_page <- body(pkgdown_env\$tweak_page)
+          body(pkgdown_env\$tweak_page) <-
             as.call(
               append(
                 as.list(tweak_page),
@@ -159,13 +153,9 @@ jobs:
                 after=length(tweak_page)
               )
             )
-
           rlang::env_binding_lock(env = pkgdown_env)
           rlang::env_lock(pkgdown_env)
-
-          # Load package
           require(desc::desc_get("Package"), character.only = TRUE)
-
           pkgdown::deploy_to_branch(
             new_process = FALSE,
             ${SUBDIR_OPTION}


### PR DESCRIPTION
I escape a special character for bash that was problematic. I didn't notice before that the script is evaluated by shell, so it was working locally.