### PR TITLE
Close #69 upgarde setup-pandoc action to v2

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -104,7 +104,7 @@ jobs:
           restore-keys: ${{ runner.os }}-renv-
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Run Staged dependencies
         uses: insightsengineering/staged-dependencies-action@v1


### PR DESCRIPTION
Close #69 upgrade setup-pandoc action to v2 as v1 is deprecated. 