### PR TITLE
Closes #38 Remove assertthat from renv.lock

### DIFF
--- a/.github/workflows/r-renv-lock.yml
+++ b/.github/workflows/r-renv-lock.yml
@@ -93,7 +93,7 @@ jobs:
                   project_dir,
                   adm_dev_suggests[["Package"]],
                   suggests_packages[["Package"]],
-                  c("staged.dependencies", "assertthat", "renv")
+                  c("staged.dependencies", "renv")
                 ))
               )
             )
@@ -173,7 +173,6 @@ jobs:
           install_min_version("pkgdown","2.0.7")
           install_min_version("lintr", "3.0.2")
           install_min_version("cli", "3.4.1")
-          install_min_version("assertthat", "0.2.1")
           install_min_version("testthat","3.1.7")
           install_min_version("styler","1.9.1")
           remotes::install_version("roxygen2", version = "7.2.1", upgrade = "never")

--- a/.github/workflows/r-renv-lock.yml
+++ b/.github/workflows/r-renv-lock.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Collect dependencies
         run: |
           source("renv/activate.R")
-          lock_gen_version <- "0.1.8"
+          lock_gen_version <- "0.1.9"
           legacy <- identical(Sys.getenv("R_RELEASE_LAGACY"), "true")
           renv_profile <- Sys.getenv("RENV_PROFILE_NAME", "dev")
           if (legacy) renv_profile <- paste0(renv_profile, "_legacy")

--- a/renv.lock
+++ b/renv.lock
@@ -120,16 +120,6 @@
       ],
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
-    },
     "backports": {
       "Package": "backports",
       "Version": "1.2.1",

--- a/renv/profiles/4.0/renv.lock
+++ b/renv/profiles/4.0/renv.lock
@@ -120,16 +120,6 @@
       ],
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
-    },
     "backports": {
       "Package": "backports",
       "Version": "1.2.1",

--- a/renv/profiles/4.1/renv.lock
+++ b/renv/profiles/4.1/renv.lock
@@ -114,16 +114,6 @@
       ],
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
-    },
     "backports": {
       "Package": "backports",
       "Version": "1.4.1",

--- a/renv/profiles/4.2/renv.lock
+++ b/renv/profiles/4.2/renv.lock
@@ -114,16 +114,6 @@
       ],
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
-    },
     "backports": {
       "Package": "backports",
       "Version": "1.4.1",


### PR DESCRIPTION
The assertthat should not be used anymore. This PR propagate the removal of assertthat from `renv.lock`. 