### PR TITLE
Update r-cmd-check.yml

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -11,12 +11,10 @@ on:
     branches:
       - main
       - devel
-      - pre-release
   pull_request:
     branches:
       - main
       - devel
-      - pre-release
 
 name: R CMD Check
 
@@ -34,8 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: '4.0', repos: 'https://packagemanager.posit.co/cran/2021-03-31/'}
-          - {os: ubuntu-20.04, r: '4.1', repos: 'https://packagemanager.posit.co/cran/2022-03-10/'}
+          - {os: ubuntu-20.04, r: '4.1', repos: 'https://packagemanager.posit.co/cran/2021-05-03/'}
+          - {os: ubuntu-20.04, r: '4.2', repos: 'https://packagemanager.posit.co/cran/2022-01-03/'}
           - {os: ubuntu-20.04, r: 'release', repos: 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'}
 
     env:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,3 +11,5 @@ https://packagemanager.posit.co/cran/2022-10-31/
 https://packagemanager.posit.co/cran/2022-03-10/
 https://github.com/pharmaverse/admiralci/blob/HEAD/
 https://packagemanager.posit.co/cran/2021-03-31/
+https://packagemanager.posit.co/cran/2022-01-03/
+https://packagemanager.posit.co/cran/2021-05-03/


### PR DESCRIPTION
* Removed 4.0
* Added 4.2
* I matched the package snapshots closer to when the R version were [released](https://packagemanager.posit.co/client/#/repos/2/overview) 
* Removed `pre-release` branch as we are no longer using it.