### PR TITLE
No local installation for coverage workflow needed

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       r-version:
         description: 'The version of R to use'
-        default: '4.2'
+        default: '4.0'
         required: false
         type: string
       skip-coverage-badges:


### PR DESCRIPTION
No need to install. `covr` already does it.