### PR TITLE
Change installation method for check templates

### DIFF
--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install package
         run: |
-          R CMD build .
+          R CMD build --no-build-vignettes --no-manual .
           R CMD INSTALL *.tar.gz
 
       - name: Run Template Scripts


### PR DESCRIPTION
Use `R CMD` to build and install.