### PR TITLE
Update pkgdown.yml

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -116,7 +116,7 @@ jobs:
       ##################### END boilerplate steps #####################
 
       - name: Install package
-        run: renv::install(".")
+        run: renv::install(".", dependencies = FALSE)
         shell: Rscript {0}
 
       - name: Publish documentation


### PR DESCRIPTION
Fix an issue with installing dependencies when default renv::install is trigger.

When the dependencies is NULL it's using `renv::settings$package.dependency.fields` function. That discover dependencies from DESCRIPTION file.

As we already have the dependencies resolve with `stage.dependencies`, setting this value to something different than NULL should solve the problem. 

I think this behavior is also different for the standard one as when the renv is not active then we are using default values. 