### PR TITLE
Add styler to dev dependencies too exlude it from DESCRIPTION

### DIFF
--- a/.github/workflows/r-renv-lock.yml
+++ b/.github/workflows/r-renv-lock.yml
@@ -92,7 +92,7 @@ jobs:
                   project_dir,
                   adm_dev_suggests[["Package"]],
                   suggests_packages[["Package"]],
-                  c("staged.dependencies", "renv")
+                  c("staged.dependencies", "renv", "styler")
                 ))
               )
             )


### PR DESCRIPTION
This PR adds styler to custom dependencies and it allows to remove styler from `DESCRIPTION` file.

This pr is part of pharmaverse/admiral#1919 and the `styler` can be removed from the `DESCRIPTION`.