### PR TITLE
Upgrade pandoc to v2 in code-coverage job.

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -100,7 +100,7 @@ jobs:
           key: staged-deps
 
       - name: Setup Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Run Staged dependencies
         uses: insightsengineering/staged-dependencies-action@v1


### PR DESCRIPTION
`r-lib/actions/setup-pandoc@v1` was deprecated, upgraded to v2. 