### PR TITLE
delete existing release artifacts

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -101,6 +101,14 @@ jobs:
           name: deps
           path: "/workspace/deps-${{ matrix.tags }}.csv"
 
+      - name: Delete current release existing artifacts
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ github.token }}
+          tag: "latest"
+          assets: |
+            Dependencies.list.of.docker.image.admiralci-${{ matrix.tags }}.csv
+
       - name: Upload SBOM to release 🔼
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
@cicdguy : I add a step here to delete existing artifacts in admiralci release (see issue https://github.com/pharmaverse/admiralci/issues/181 ) - but not sure.. for me it should be temporary fix, because the issue is more coming from downstream upload-release-action where option `overwrite: true` is not working (as I mentioned on the issue https://github.com/pharmaverse/admiralci/issues/181)