### PR TITLE
Forces remotes to work in standalone

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -99,6 +99,8 @@ jobs:
         run: |
           devtools::install(force = TRUE, dependencies = TRUE)
         shell: Rscript {0}
+        env:
+          R_REMOTES_STANDALONE: "true"
       ##################### END boilerplate steps #####################
 
       - name: Run coverage 👟

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -84,6 +84,8 @@ jobs:
         run: |
           devtools::install(force = TRUE, dependencies = TRUE)
         shell: Rscript {0}
+        env:
+          R_REMOTES_STANDALONE: "true"
 
       ##################### END boilerplate steps #####################
 


### PR DESCRIPTION
Forces remotes to work in standalone mode and avoid loading its optional dependencies (curl, git2 and pkgbuild).

This should fix the issue with man and coverege job as upgrading pkgbuild breaks future execution of the job. 