### PR TITLE
Replace devtools with remotes in man and cov jobs. 

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install dependencies from DESCRIPTION
         run: |
-          devtools::install(force = TRUE, dependencies = TRUE)
+          remotes::install_local(force = TRUE, dependencies = TRUE)
         shell: Rscript {0}
         env:
           R_REMOTES_STANDALONE: "true"

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies from DESCRIPTION
         run: |
-          devtools::install(force = TRUE, dependencies = TRUE)
+          remotes::install_local(force = TRUE, dependencies = TRUE)
         shell: Rscript {0}
         env:
           R_REMOTES_STANDALONE: "true"


### PR DESCRIPTION
Replace devtools with remotes as it works as expected. 

The devtools do use flags from remotes and the implementation is a little different. 